### PR TITLE
Fix: improve performance

### DIFF
--- a/Extension/ASD.ESH/Classification/Classifier.SpansConverter.cs
+++ b/Extension/ASD.ESH/Classification/Classifier.SpansConverter.cs
@@ -20,9 +20,9 @@ namespace ASD.ESH.Classification {
 
         internal sealed class SpansConverter {
 
-            private SemanticModel model;
-            private SyntaxNode root;
-            private ITextSnapshot snapshot;
+            private readonly SemanticModel model;
+            private readonly SyntaxNode root;
+            private readonly ITextSnapshot snapshot;
 
             public SpansConverter(SemanticModel model, SyntaxNode root, ITextSnapshot snapshot) {
                 this.model = model; this.root = root; this.snapshot = snapshot;
@@ -30,6 +30,7 @@ namespace ASD.ESH.Classification {
 
             public IEnumerable<ClassificationSpan> ConvertAll(IEnumerable<ClassifiedSpan> spans) {
                 return spans
+                    .AsParallel()
                     .Where(s => s.ClassificationType == ClassificationTypeNames.Identifier
                         || (s.ClassificationType.EndsWith("name") && !s.ClassificationType.StartsWith("xml")))
                     .Select(Convert)

--- a/Extension/ASD.ESH/Classification/Classifier.cs
+++ b/Extension/ASD.ESH/Classification/Classifier.cs
@@ -43,10 +43,10 @@ namespace ASD.ESH.Classification {
             this.document = document;
             this.snapshot = snapshot;
 
-            return lastSpans = GetSpansAync(document, snapshot).ConfigureAwait(false).GetAwaiter().GetResult();
+            return lastSpans = GetSpansAsync(document, snapshot).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        private async Task<IList<ClassificationSpan>> GetSpansAync(Document document, ITextSnapshot snapshot) {
+        private async Task<IList<ClassificationSpan>> GetSpansAsync(Document document, ITextSnapshot snapshot) {
 
             var model = await document.GetSemanticModelAsync().ConfigureAwait(false);
             var root = await document.GetSyntaxRootAsync().ConfigureAwait(false);

--- a/Extension/ASD.ESH/Classification/Classifier.cs
+++ b/Extension/ASD.ESH/Classification/Classifier.cs
@@ -52,15 +52,8 @@ namespace ASD.ESH.Classification {
             var rootTask = document.GetSyntaxRootAsync();
             var spansTask = document.GetClassifiedSpansAsync(new TextSpan(0, snapshot.Length));
             await Task.WhenAll(modelTask, rootTask, spansTask).ConfigureAwait(false);
-            var spans = spansTask.Result;
-
-            var resultSpans = new List<ClassificationSpan>(spans.Count());
             var converter = new SpansConverter(modelTask.Result, rootTask.Result, snapshot);
-
-            foreach (var span in converter.ConvertAll(spans)) {
-                resultSpans.Add(span);
-            }
-            return resultSpans;
+            return converter.ConvertAll(spansTask.Result).ToList();
         }
     }
 }

--- a/Extension/ASD.ESH/Classification/ClassifierProvider.cs
+++ b/Extension/ASD.ESH/Classification/ClassifierProvider.cs
@@ -14,9 +14,9 @@ namespace ASD.ESH.Classification {
     [ContentType("CSharp"), ContentType("Basic")]
     internal sealed class ClassifierProvider : IClassifierProvider {
 
-#pragma warning disable CS0649
+#pragma warning disable CS0649, IDE0044, RCS1169
         [Import] private IClassificationTypeRegistryService registryService; // set via MEF
-#pragma warning restore CS0649
+#pragma warning restore CS0649, IDE0044, RCS1169
 
         IClassifier IClassifierProvider.GetClassifier(ITextBuffer textBuffer) {
 

--- a/Extension/ASD.ESH/Classification/TypesRegistry.Definitions.cs
+++ b/Extension/ASD.ESH/Classification/TypesRegistry.Definitions.cs
@@ -13,7 +13,7 @@ namespace ASD.ESH.Classification {
 
     internal static partial class TypesRegistry {
 
-        private sealed class Definitions {
+        private static class Definitions {
 
             private static class DefaultColor {
                 public const string Blue = "#9CDCFE";
@@ -139,11 +139,12 @@ namespace ASD.ESH.Classification {
 
             private abstract class FormatDefinition : ClassificationFormatDefinition {
 
-                public FormatDefinition(string displayName, string defaultForegroundColor) : this(displayName) {
+                protected FormatDefinition(string displayName, string defaultForegroundColor) : this(displayName) {
                     ForegroundColor = (Color)ColorConverter
                         .ConvertFromString(defaultForegroundColor);
                 }
-                public FormatDefinition(string displayName) {
+
+                protected FormatDefinition(string displayName) {
                     DisplayName = $"User Tags - {displayName}";
                 }
             }


### PR DESCRIPTION
Tried to increase performance with:
1. Using PLINQ instead of LINQ.
2. Removing redundant list creation because we can just use `ToList()`.
3. Using `Task.WhenAll` to parallelize task execution. While `ConfigureAwait(false)` caused to continue execution of other threads, 3 tasks weren't executed in parallel.
Visualization of how `ConfigureAwait(false)` works: https://blogs.msdn.microsoft.com/benwilli/2015/09/10/tasks-are-still-not-threads-and-async-is-not-parallel/